### PR TITLE
feat(Arrow IPC error handling):

### DIFF
--- a/data/datastream.go
+++ b/data/datastream.go
@@ -158,6 +158,8 @@ func ParseAndExecuteTemplate(data []byte, config *StreamConfig) ([]byte, error) 
 func ext(config *StreamConfig) string {
 	var ext string
 	switch strings.ToLower(config.Format) {
+	case "arrow":
+		ext = ".arrow"
 	case "csv":
 		ext = ".csv"
 	case "jsonl":

--- a/file/arrow.go
+++ b/file/arrow.go
@@ -40,10 +40,9 @@ func NewArrowDataWriter(datastream *data.DataStream, w io.Writer) *ArrowDataWrit
 	for i, col := range datastream.DestColumns {
 		// Add column metadata to preserve type information
 		metadata := arrow.NewMetadata(
-			[]string{"original_type", "precision", "scale", "length"},
-			[]string{col.Type,
-				cast.ToString(col.Precision),
-				cast.ToString(col.Scale),
+			[]string{"name", "type", "length"},
+			[]string{col.Name,
+				col.Type,
 				cast.ToString(col.Length)},
 		)
 

--- a/file/file.go
+++ b/file/file.go
@@ -245,6 +245,7 @@ func WriteEmptyFile(format string, writer io.Writer) error {
 		recordBuilder := array.NewRecordBuilder(alloc, schema)
 		emptyBatch := recordBuilder.NewRecord()
 		defer recordBuilder.Release()
+		defer emptyBatch.Release()
 		if err := arrowWriter.Write(emptyBatch); err != nil {
 			return err
 		}

--- a/file/parquet_writer.go
+++ b/file/parquet_writer.go
@@ -25,9 +25,9 @@ import (
 var epochDate = time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 
 type ColumnMetadata struct {
-	Name string `json:"name"`
-	Type string `json:"type"`
-	Len  int32  `json:"len"`
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Length int32  `json:"length"`
 }
 
 type ParquetDataWriter struct {
@@ -108,7 +108,7 @@ func checkType(col data.Column) MappedType {
 func mapColumnMetadata(columns []data.Column) []ColumnMetadata {
 	columnMetadata := make([]ColumnMetadata, len(columns))
 	for col := range columns {
-		columnMetadata[col] = ColumnMetadata{Name: columns[col].Name, Type: columns[col].Type, Len: int32(columns[col].Length)}
+		columnMetadata[col] = ColumnMetadata{Name: columns[col].Name, Type: columns[col].Type, Length: int32(columns[col].Length)}
 	}
 
 	return columnMetadata


### PR DESCRIPTION
When outputting to Arrow MVR in stdout, MVR will output an empty schema and arrow file. This will allow ldrs to handle process the output and the error from mvr. Fixed batch size flag for the mv command.